### PR TITLE
Add keypress to close modal and remove background scrolling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,11 +33,23 @@ export default class ReactConfirmAlert extends Component {
   }
 
   close = () => {
+    removeBodyClass()
     removeElementReconfirm()
     removeSVGBlurReconfirm()
   }
 
+  keyboardClose = event => {
+    if (event.keyCode === 27) {
+      this.close()
+    }
+  }
+
+  componentDidMount = () => {
+    document.addEventListener('keydown', this.keyboardClose, false)
+  }
+
   componentWillUnmount = () => {
+    document.removeEventListener('keydown', this.keyboardClose, false)
     this.props.willUnmount()
   }
 
@@ -118,7 +130,16 @@ function removeElementReconfirm () {
   target.parentNode.removeChild(target)
 }
 
+function addBodyClass () {
+  document.body.classList.add('react-confirm-alert-body-element')
+}
+
+function removeBodyClass () {
+  document.body.classList.remove('react-confirm-alert-body-element')
+}
+
 export function confirmAlert (properties) {
+  addBodyClass()
   createSVGBlurReconfirm()
   createElementReconfirm(properties)
 }

--- a/src/react-confirm-alert.css
+++ b/src/react-confirm-alert.css
@@ -1,3 +1,7 @@
+body.react-confirm-alert-body-element {
+  overflow: hidden;
+}
+
 .react-confirm-alert-blur {
   filter: url(#gaussian-blur);
   filter: blur(2px);
@@ -27,8 +31,6 @@
   animation: react-confirm-alert-fadeIn 0.5s 0.2s forwards;
 }
 
-.react-confirm-alert {}
-
 .react-confirm-alert-body {
   font-family: Arial, Helvetica, sans-serif;
   width: 400px;
@@ -40,7 +42,7 @@
   color: #666;
 }
 
-.react-confirm-alert-svg{
+.react-confirm-alert-svg {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Add the ability to close the modal with the ESC key and removes the scrollbar when the alert is being shown, fixes issue #9.