### PR TITLE
node prop type for message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { render, unmountComponentAtNode } from 'react-dom'
 export default class ReactConfirmAlert extends Component {
   static propTypes = {
     title: PropTypes.string,
-    message: PropTypes.string,
+    message: PropTypes.node,
     buttons: PropTypes.array.isRequired,
     childrenElement: PropTypes.func,
     customUI: PropTypes.func,


### PR DESCRIPTION
Hello.

The message prop should allow the node type rather than just a string. It works fine when passing a node but complains on the prop type.