### PR TITLE
JS error "TypeError: Cannot read property 'parentNode' of null"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,9 @@ function createSVGBlurReconfirm () {
 
 function removeSVGBlurReconfirm (afterClose) {
   const svg = document.getElementById('react-confirm-alert-firm-svg')
-  svg.parentNode.removeChild(svg)
+  if (svg) {
+    svg.parentNode.removeChild(svg)
+  }
   document.body.children[0].classList.remove('react-confirm-alert-blur')
   afterClose()
 }


### PR DESCRIPTION
If the onClose method is called on the unmounted alert, this error occurred: 
"TypeError: Cannot read property 'parentNode' of null"

I added an extra check to fix this error.