### PR TITLE
add keyboardClose with enter key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-confirm-alert' {
     willUnmount?: () => void
     onClickOutside?: () => void
     onKeypressEscape?: () => void
+    onkeyPressEnter?: () => void
     overlayClassName?: string
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,10 @@ export default class ReactConfirmAlert extends Component {
     closeOnEscape: PropTypes.bool,
     willUnmount: PropTypes.func,
     afterClose: PropTypes.func,
+    afterEnter: PropTypes.func,
     onClickOutside: PropTypes.func,
     onKeypressEscape: PropTypes.func,
+    onkeyPressEnter: PropTypes.func,
     overlayClassName: PropTypes.string
   }
 
@@ -63,12 +65,17 @@ export default class ReactConfirmAlert extends Component {
   }
 
   keyboardClose = event => {
-    const { closeOnEscape, onKeypressEscape } = this.props
+    const { closeOnEscape, onKeypressEscape, onkeyPressEnter, afterEnter } = this.props
     const isKeyCodeEscape = event.keyCode === 27
+    const isKeyCodeEnter = event.keyCode === 13
 
     if (closeOnEscape && isKeyCodeEscape) {
       onKeypressEscape(event)
       this.close()
+    } else if (closeOnEscape && isKeyCodeEnter) {
+      onkeyPressEnter(event)
+      this.close()
+      afterEnter()
     }
   }
 


### PR DESCRIPTION
This feature allow users to press enter key to close the alert. Also, after enter method will be triggered when the alert disappears.