### PR TITLE
Add stopPropagation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,8 @@ export default class ReactConfirmAlert extends Component {
       onClickOutside()
       this.close()
     }
+
+    e.stopPropagation()
   }
 
   close = () => {


### PR DESCRIPTION
Shouldn't this library be stopPropagation?
If used at the same time as other modal or other elements, it will close them in a way that is not intended by the user.
And since I am still using 2.x, it would be great if this could be reflected in the latest 2.x version if possible.

Thanks for a great library :heart: