### PR TITLE
Fix TS definition for the 'buttons' property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import React, { ButtonHTMLAttributes } from 'react';
+
 declare module 'react-confirm-alert' {
   export interface ReactConfirmAlertProps {
     targetId?: string
@@ -6,7 +8,7 @@ declare module 'react-confirm-alert' {
     buttons?: Array<{
       label: string
       className?: string
-    } & HTMLButtonElement>
+    } & ButtonHTMLAttributes<HTMLButtonElement>>
     childrenElement?: () => React.ReactNode
     customUI?: (customUiOptions: {
       title: string


### PR DESCRIPTION
### The problem

Here's the `index.d.ts` code currently in the `master`:

```typescript
buttons?: Array<{
  label: string
  className?: string
} & HTMLButtonElement>
```

These type definitions break even the code from the docs with the following error:
![image](https://user-images.githubusercontent.com/3861811/177854217-27c8f767-eef9-4190-baba-6a4a9f894a2f.png)

`onClick` won't let my code compile, so for now I had to suppress the error.

Here's why it breaks. `HTMLButtonElement` is an interface describing a vanilla DOM `button` element. So it has a lowercased `onclick` and a whole lot of other required fields (about 300 of them) which you will need to specify in order to get your code to compile.

### What's in the PR

I updated the d.ts-file and used the interface which React itself uses for buttons.
It has a normal React-style `onClick` and other optional fields relevant for buttons and the inherited ones.